### PR TITLE
Update manifest.json to remove unneeded deps

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
     },
     "linux-x64" : {
       "dependencies" : [],
-      "linked-libraries" : ["raylib", "GLESv2", "glfw", "c"]
+      "linked-libraries" : ["raylib", "c"]
     },
     "windows-x64" : {
       "linked-libraries" : ["raylib", "opengl32", "kernel32", "user32", "gdi32", "winmm", "winspool", "comdlg32", "advapi32", "shell32", "ole32", "oleaut32", "uuid", "odbc32", "odbccp32"],


### PR DESCRIPTION
Those are already statically shipped in raylib itself. I was told so on discord, and it really looks like that is the  case.